### PR TITLE
Add Assignee Column. Fixes #3

### DIFF
--- a/client/src/components/Assignees.js
+++ b/client/src/components/Assignees.js
@@ -1,0 +1,14 @@
+import React from 'react'
+
+const Assignees = assignee => {
+  const person = assignee.assignee;
+  if (person) {
+      return (
+      <a href={person.html_url}>
+        <img title={person.login} src={person.avatar_url} />
+      </a>
+    )
+  }
+}
+
+export default Assignees

--- a/client/src/components/IssueList.js
+++ b/client/src/components/IssueList.js
@@ -8,8 +8,8 @@ const IssueList = ({ issues }) => {
         <tr>
           <th>Issue</th>
           <th>Tags</th>
-          <th>Opened On</th>
-          <th>Assigned To</th>
+          <th className='date'>Opened On</th>
+          <th className='assignee'>Assigned To</th>
         </tr>
       </thead>
       <tbody>

--- a/client/src/components/IssueList.js
+++ b/client/src/components/IssueList.js
@@ -9,6 +9,7 @@ const IssueList = ({ issues }) => {
           <th>Issue</th>
           <th>Tags</th>
           <th>Opened On</th>
+          <th>Assigned To</th>
         </tr>
       </thead>
       <tbody>

--- a/client/src/components/IssueRow.js
+++ b/client/src/components/IssueRow.js
@@ -5,11 +5,11 @@ import Assignees from './Assignees'
 const IssueRow = ({ issue }) => {
   return (
     <tr>
-      <td>
+      <td className='issue'>
         <a href={issue.html_url}>{issue.title}</a>
       </td>
-      <td>{issue.labels.map(l => l.name).join(', ')}</td>
-      <td>{moment(issue.created_at).format('MMM D, YYYY')}</td>
+      <td className='tags'>{issue.labels.map(l => l.name).join(', ')}</td>
+      <td className='date'>{moment(issue.created_at).format('MMM D, YYYY')}</td>
       <td className='assignee'>{issue.assignees.map(assignee => (<Assignees assignee={assignee} />))}</td>
     </tr>
   )

--- a/client/src/components/IssueRow.js
+++ b/client/src/components/IssueRow.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import moment from 'moment'
+import Assignees from './Assignees'
 
 const IssueRow = ({ issue }) => {
   return (
@@ -9,6 +10,7 @@ const IssueRow = ({ issue }) => {
       </td>
       <td>{issue.labels.map(l => l.name).join(', ')}</td>
       <td>{moment(issue.created_at).format('MMM D, YYYY')}</td>
+      <td className='assignee'>{issue.assignees.map(assignee => (<Assignees assignee={assignee} />))}</td>
     </tr>
   )
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,1 +1,7 @@
-
+.assignee {
+  text-align: center;
+}
+img {
+  width: 1.5em;
+  height: 1.5em;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,4 +1,16 @@
+.issue {
+  width: 60%;
+}
+.tags {
+  width: 20%
+}
+.date {
+  width: 10%;
+}
 .assignee {
+  width: 10%
+}
+.date, .assignee {
   text-align: center;
 }
 img {


### PR DESCRIPTION
Added an "Assigned To" column:

* An avatar of each assignee is added and wrapped in a link to their GitHub profile.
* A title attribute was added to show the assignee's name.
* Centered the "Opened On" and "Assigned To" column content.
* Set specific column widths so all tables have the same style.

![](https://user-images.githubusercontent.com/136959/28148319-8665343a-674b-11e7-8c97-f84b1f45435f.png)

