### PR TITLE
Add withData hoc for data fetching

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -1,9 +1,20 @@
 import React from 'react'
 import Repo from './Repo'
+import withData from './withData'
 
 const sortRepos = repos => repos.sort((a, b) => new Date(b.repo.pushed_at) - new Date(a.repo.pushed_at))
 
-const App = ({ data }) => {
+const styles = {
+  big: {
+    fontSize: '36px',
+    textAlign: 'center',
+    marginTop: '50vh'
+  }
+}
+
+const App = ({ data, isLoading }) => {
+  if (isLoading) return <div style={styles.big}>Loading Issues...</div>
+
   return (
     <div className='container'>
       <div className='row App-header'>
@@ -21,4 +32,4 @@ const App = ({ data }) => {
   )
 }
 
-export default App
+export default withData()(App)

--- a/client/src/components/Assignees.js
+++ b/client/src/components/Assignees.js
@@ -5,7 +5,7 @@ const Assignees = assignee => {
   if (person) {
       return (
       <a href={person.html_url}>
-        <img title={person.login} src={person.avatar_url} />
+        <img title={person.login} src={person.avatar_url} alt='avatar' />
       </a>
     )
   }

--- a/client/src/components/withData.js
+++ b/client/src/components/withData.js
@@ -1,0 +1,47 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+const withData = props => WrappedComponent => {
+  return class WithData extends Component {
+    static defaultProps = {
+      url: 'https://7kwo0tuep0.execute-api.us-east-1.amazonaws.com/dev/github/data'
+    }
+
+    static propTypes = {
+      url: PropTypes.string
+    }
+
+    state = {
+      data: null,
+      error: null,
+      isLoading: true
+    }
+
+    async componentDidMount () {
+      const headers = { header: new Headers({'content-type': 'application/json'})}
+
+      try {
+        const res = await fetch(this.props.url, headers)
+        const { data } = await res.json()
+        this.setState({data})
+      } catch (error) {
+        this.setState({error})
+      } finally {
+        this.setState({isLoading: false})
+      }
+    }
+
+    render () {
+      return (
+        <WrappedComponent 
+          {...props} 
+          data={this.state.data} 
+          error={this.state.error}
+          isLoading={this.state.isLoading}
+        />
+      )
+    }
+  }
+}
+
+export default withData

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -7,9 +7,5 @@ import registerServiceWorker from './registerServiceWorker'
 
 import './index.css'
 
-fetch('https://7kwo0tuep0.execute-api.us-east-1.amazonaws.com/dev/github/data', {
-  headers: new Headers({ 'content-type': 'application/json' })
-}).then(response => response.json()).then(({ data }) => {
-  ReactDOM.render(<App data={data} />, document.getElementById('root'))
-  registerServiceWorker()
-}).catch(console.log)
+ReactDOM.render(<App />, document.getElementById('root'))
+registerServiceWorker()


### PR DESCRIPTION
Fix missing alt prop on img tag warning.

Add withData higher order component for fetching data and injecting response as props. It just takes a url right now so any component that needs to fetch data can just be wrapped in it and passed a url and it will receive `data`, `error`, and `isLoading` props to work with. 

This is also pretty much how react-apollo works, which you can use to fetch data from the github graphql api, so this could be a good way to help transition to that if anyone wants to try that out.